### PR TITLE
Method names in ElasticsearchQueryBuilderInterface change

### DIFF
--- a/src/ElasticsearchQueryBuilderInterface.php
+++ b/src/ElasticsearchQueryBuilderInterface.php
@@ -31,7 +31,7 @@ interface ElasticsearchQueryBuilderInterface extends PluginInspectionInterface {
    *
    * @return array
    */
-  public function getValuesFromView(ViewExecutable $view);
+  public function getFilterValues(ViewExecutable $view);
 
   /**
    * Returns argument values from a view.
@@ -40,6 +40,6 @@ interface ElasticsearchQueryBuilderInterface extends PluginInspectionInterface {
    *
    * @return array
    */
-  public function getArgumentsFromView(ViewExecutable $view);
+  public function getArgumentValues(ViewExecutable $view);
 
 }

--- a/src/Plugin/ElasticsearchQueryBuilder/ElasticsearchQueryBuilderPluginBase.php
+++ b/src/Plugin/ElasticsearchQueryBuilder/ElasticsearchQueryBuilderPluginBase.php
@@ -34,11 +34,11 @@ abstract class ElasticsearchQueryBuilderPluginBase extends PluginBase implements
   /**
    * {@inheritdoc}
    */
-  public function getValuesFromView(ViewExecutable $view) {
+  public function getFilterValues(ViewExecutable $view) {
     $values = [];
     /** @var \Drupal\views\Plugin\views\filter\FilterPluginBase $filter */
-    foreach ($view->filter as $field_name => $filter) {
-      $values[$field_name] = $filter->value;
+    foreach ($view->filter as $name => $filter) {
+      $values[$name] = $filter->value;
     }
     return $values;
   }
@@ -46,11 +46,11 @@ abstract class ElasticsearchQueryBuilderPluginBase extends PluginBase implements
   /**
    * {@inheritdoc}
    */
-  public function getArgumentsFromView(ViewExecutable $view) {
+  public function getArgumentValues(ViewExecutable $view) {
     $arguments = [];
     /** @var \Drupal\views\Plugin\views\argument\ArgumentPluginBase $argument */
-    foreach ($view->argument as $argument_name => $argument) {
-      $arguments[$argument_name] = $argument->argument;
+    foreach ($view->argument as $name => $argument) {
+      $arguments[$name] = $argument->getValue();
     }
     return $arguments;
   }

--- a/src/Plugin/views/query/Elasticsearch.php
+++ b/src/Plugin/views/query/Elasticsearch.php
@@ -136,6 +136,26 @@ class Elasticsearch extends QueryPluginBase {
   }
 
   /**
+   * Placeholder method.
+   *
+   * @param $table
+   * @param null $field
+   * @param string $order
+   * @param string $alias
+   * @param array $params
+   */
+  public function addOrderBy($table, $field = NULL, $order = 'ASC', $alias = '', $params = array()) {
+  }
+
+  /**
+   * Placeholder method.
+   *
+   * @param $clause
+   */
+  public function addGroupBy($clause) {
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function query($get_count = FALSE) {


### PR DESCRIPTION
Methods changed in `ElasticsearchQueryBuilderInterface` and implementing classes:
- `getValuesFromView()` => `getFilterValues()`
- `getArgumentsFromView()` => `getArgumentValues()`

Methods added to `Elasticsearch` views query class:
- `addOrderBy() `
- `addGroupBy()`