### PR TITLE
Method getSortValues() added to ElasticsearchQueryBuilderInterface

### DIFF
--- a/src/ElasticsearchQueryBuilderInterface.php
+++ b/src/ElasticsearchQueryBuilderInterface.php
@@ -42,4 +42,13 @@ interface ElasticsearchQueryBuilderInterface extends PluginInspectionInterface {
    */
   public function getArgumentValues(ViewExecutable $view);
 
+  /**
+   * Returns sort values from a view.
+   *
+   * @param \Drupal\views\ViewExecutable $view
+   *
+   * @return array
+   */
+  public function getSortValues(ViewExecutable $view);
+
 }

--- a/src/Plugin/ElasticsearchQueryBuilder/ElasticsearchQueryBuilderPluginBase.php
+++ b/src/Plugin/ElasticsearchQueryBuilder/ElasticsearchQueryBuilderPluginBase.php
@@ -37,8 +37,8 @@ abstract class ElasticsearchQueryBuilderPluginBase extends PluginBase implements
   public function getFilterValues(ViewExecutable $view) {
     $values = [];
     /** @var \Drupal\views\Plugin\views\filter\FilterPluginBase $filter */
-    foreach ($view->filter as $name => $filter) {
-      $values[$name] = $filter->value;
+    foreach ($view->filter as $filter) {
+      $values[$filter->realField] = $filter->value;
     }
     return $values;
   }
@@ -49,8 +49,20 @@ abstract class ElasticsearchQueryBuilderPluginBase extends PluginBase implements
   public function getArgumentValues(ViewExecutable $view) {
     $arguments = [];
     /** @var \Drupal\views\Plugin\views\argument\ArgumentPluginBase $argument */
-    foreach ($view->argument as $name => $argument) {
-      $arguments[$name] = $argument->getValue();
+    foreach ($view->argument as $argument) {
+      $arguments[$argument->realField] = $argument->getValue();
+    }
+    return $arguments;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSortValues(ViewExecutable $view) {
+    $arguments = [];
+    /** @var \Drupal\views\Plugin\views\sort\SortPluginBase $sort */
+    foreach ($view->sort as $sort) {
+      $arguments[$sort->realField] = strtolower($sort->options['order']);
     }
     return $arguments;
   }


### PR DESCRIPTION
+ Element names in `getFilterValues()`, `getArgumentValues()` and `getSortValues()` are `realField` values.