### PR TITLE
An option to print Elasticsearch query to browser console added

### DIFF
--- a/elasticsearch_helper_views.libraries.yml
+++ b/elasticsearch_helper_views.libraries.yml
@@ -1,0 +1,6 @@
+debug:
+  version: VERSION
+  js:
+    js/debug.js : {}
+  dependencies:
+    - core/drupal

--- a/elasticsearch_helper_views.services.yml
+++ b/elasticsearch_helper_views.services.yml
@@ -2,3 +2,8 @@ services:
   elasticsearch_query_builder.manager:
     class: Drupal\elasticsearch_helper_views\ElasticsearchQueryBuilderManager
     arguments: ['@container.namespaces', '@cache.discovery', '@module_handler']
+  elasticsearch_helper_views.ajax_subscriber:
+    class: Drupal\elasticsearch_helper_views\EventSubscriber\AjaxResponseSubscriber
+    arguments: ['@current_user', '@config.factory']
+    tags:
+      - { name: event_subscriber }

--- a/js/debug.js
+++ b/js/debug.js
@@ -1,0 +1,24 @@
+(function (Drupal) {
+
+  "use strict";
+
+  /**
+   * Ajax 'elasticsearch_query_debug' command: prints Elasticsearch query to console for debuggin.
+   *
+   * @param {Drupal.Ajax} ajax
+   *   An Ajax object.
+   * @param {object} response
+   *   The Ajax response.
+   * @param {string} response.data
+   *    The Ajax response's content.
+   * @param {number} [status]
+   *   The HTTP status code.
+   */
+  Drupal.AjaxCommands.prototype.elasticsearch_query_debug = function (ajax, response, status) {
+    if (console && console.log) {
+      var json = (typeof response.text == 'object' ? response.text : JSON.parse(response.text));
+      console.log(JSON.stringify(json, null, 2));
+    }
+  };
+
+})(Drupal);

--- a/src/Ajax/ElasticsearchDebugCommand.php
+++ b/src/Ajax/ElasticsearchDebugCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_views\Ajax;
+
+use Drupal\Core\Ajax\CommandInterface;
+
+/**
+ * Prints Elasticsearch query to console for debugging.
+ *
+ * @ingroup ajax
+ */
+class ElasticsearchDebugCommand implements CommandInterface {
+
+  /** @var string $text */
+  protected $text;
+
+  /**
+   * ElasticsearchPrintToConsoleCommand constructor.
+   *
+   * @param $text
+   */
+  public function __construct($text) {
+    $this->text = $text;
+  }
+
+  /**
+   * Implements \Drupal\Core\Ajax\CommandInterface:render().
+   */
+  public function render() {
+    return array(
+      'command' => 'elasticsearch_query_debug',
+      'text' => $this->text,
+    );
+  }
+
+}

--- a/src/EventSubscriber/AjaxResponseSubscriber.php
+++ b/src/EventSubscriber/AjaxResponseSubscriber.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_views\EventSubscriber;
+
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\elasticsearch_helper_views\Ajax\ElasticsearchDebugCommand;
+use Drupal\elasticsearch_helper_views\Plugin\views\query\Elasticsearch;
+use Drupal\views\Ajax\ViewAjaxResponse;
+use Drupal\views\ViewExecutable;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Class AjaxResponseSubscriber
+ */
+class AjaxResponseSubscriber implements EventSubscriberInterface {
+
+  /** @var \Drupal\Core\Session\AccountInterface $currentUser */
+  protected $currentUser;
+
+  /** @var \Drupal\Core\Config\ConfigFactoryInterface $configFactory */
+  protected $configFactory;
+
+  /**
+   * AjaxResponseSubscriber constructor.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   */
+  public function __construct(AccountInterface $current_user, ConfigFactoryInterface $config_factory) {
+    $this->currentUser = $current_user;
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [KernelEvents::RESPONSE => 'onResponse'];
+  }
+
+  /**
+   * Prints Elasticsearch query to console for debugging.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+   */
+  public function onResponse(FilterResponseEvent $event) {
+    // Do nothing if use does not have permission to administer views.
+    if (!$this->currentUser->hasPermission('administer views')) {
+      return;
+    }
+
+    // Do nothing if "Show SQL query" setting is disabled.
+    if (!$this->configFactory->get('views.settings')->get('ui.show.sql_query.enabled')) {
+      return;
+    }
+
+    // Get response.
+    $response = $event->getResponse();
+
+    if ($response instanceof ViewAjaxResponse) {
+      // Get view.
+      $view = $response->getView();
+
+      if ($view->ajaxEnabled() && $queryHandler = $view->getQuery()) {
+        if ($queryHandler instanceof Elasticsearch) {
+          $this->addDebugCommand($response, $view);
+        }
+      }
+    }
+  }
+
+  /**
+   * Adds debug command to response.
+   */
+  protected function addDebugCommand(AjaxResponse $response, ViewExecutable $view) {
+    $response->addAttachments(['library' => ['elasticsearch_helper_views/debug']]);
+    $response->addCommand(new ElasticsearchDebugCommand($view->build_info['query']));
+  }
+
+}


### PR DESCRIPTION
Note: Elasticsearch query is printed to console only if user has permission `administer views` and if `Show the SQL query` option is selected in Views settings.