### PR TITLE
Query plugin ID fix

### DIFF
--- a/elasticsearch_helper_views.module
+++ b/elasticsearch_helper_views.module
@@ -41,7 +41,7 @@ function elasticsearch_helper_views_views_data() {
     'field' => 'id',
     'title' => t('Elasticsearch result'),
     'help' => t('Elasticsearch result'),
-    'query_id' => 'elasticsearch_api_query',
+    'query_id' => 'elasticsearch_query',
   ];
 
   $data['elasticsearch_result']['rendered_entity'] = [


### PR DESCRIPTION
A bug fixed that would throw `The elasticsearch_api_query plugin does not exist` exception (wrong query plugin ID in `elasticsearch_helper_views_views_data()`).