### PR TITLE
A typo in "elasticsearch" query plugin settings name fixed

### DIFF
--- a/src/Plugin/views/query/Elasticsearch.php
+++ b/src/Plugin/views/query/Elasticsearch.php
@@ -71,7 +71,7 @@ class Elasticsearch extends QueryPluginBase {
    */
   protected function setOptionDefaults(array &$storage, array $options) {
     parent::setOptionDefaults($storage, $options);
-    $storage['elasticserach_query_builder'] = '';
+    $storage['elasticsearch_query_builder'] = '';
   }
 
   /**
@@ -88,12 +88,12 @@ class Elasticsearch extends QueryPluginBase {
       $query_builder_options[$query_builder_plugin['id']] = sprintf('%s (%s)', $query_builder_plugin['label'], $query_builder_plugin['id']);
     }
 
-    $form['elasticserach_query_builder'] = array(
+    $form['elasticsearch_query_builder'] = array(
       '#type' => 'select',
       '#title' => $this->t('Elasticsearch query builder'),
       '#empty_value' => '',
       '#options' => $query_builder_options,
-      '#default_value' => $this->options['elasticserach_query_builder'],
+      '#default_value' => $this->options['elasticsearch_query_builder'],
       '#required' => FALSE,
     );
   }
@@ -160,7 +160,7 @@ class Elasticsearch extends QueryPluginBase {
    */
   public function query($get_count = FALSE) {
     /** @var ElasticsearchQueryBuilderInterface $query_builder */
-    $query_builder = $this->elasticsearchQueryBuilderManager->createInstance($this->options['elasticserach_query_builder']);
+    $query_builder = $this->elasticsearchQueryBuilderManager->createInstance($this->options['elasticsearch_query_builder']);
     $query = $query_builder->buildQuery($this->view);
 
     // Apply limit and offset to the query.

--- a/src/Plugin/views/query/Elasticsearch.php
+++ b/src/Plugin/views/query/Elasticsearch.php
@@ -71,7 +71,7 @@ class Elasticsearch extends QueryPluginBase {
    */
   protected function setOptionDefaults(array &$storage, array $options) {
     parent::setOptionDefaults($storage, $options);
-    $storage['elasticsearch_query_builder'] = '';
+    $storage['query_builder'] = '';
   }
 
   /**
@@ -88,12 +88,12 @@ class Elasticsearch extends QueryPluginBase {
       $query_builder_options[$query_builder_plugin['id']] = sprintf('%s (%s)', $query_builder_plugin['label'], $query_builder_plugin['id']);
     }
 
-    $form['elasticsearch_query_builder'] = array(
+    $form['query_builder'] = array(
       '#type' => 'select',
       '#title' => $this->t('Elasticsearch query builder'),
       '#empty_value' => '',
       '#options' => $query_builder_options,
-      '#default_value' => $this->options['elasticsearch_query_builder'],
+      '#default_value' => $this->options['query_builder'],
       '#required' => FALSE,
     );
   }
@@ -160,7 +160,7 @@ class Elasticsearch extends QueryPluginBase {
    */
   public function query($get_count = FALSE) {
     /** @var ElasticsearchQueryBuilderInterface $query_builder */
-    $query_builder = $this->elasticsearchQueryBuilderManager->createInstance($this->options['elasticsearch_query_builder']);
+    $query_builder = $this->elasticsearchQueryBuilderManager->createInstance($this->options['query_builder']);
     $query = $query_builder->buildQuery($this->view);
 
     // Apply limit and offset to the query.


### PR DESCRIPTION
Settings property of `elasticsearch` plugin was mistakenly named `elasticserach_query_builder`. This PR fixes that by naming the option `query_builder`.

Note: This change does not provide an update to existing Drupal configuration where erroneous setting name might be used. If you use `elasticsearch_helper_views` in your projects, search and replace instances of `elasticserach_query_builder` to `query_builder` in your configuration files.