### PR TITLE
Provide json of the elasticsearch query in views_ui preview

### DIFF
--- a/elasticsearch_helper_views.module
+++ b/elasticsearch_helper_views.module
@@ -54,3 +54,16 @@ function elasticsearch_helper_views_views_data() {
 
   return $data;
 }
+
+/**
+ * Implements hook_views_preview_info_alter().
+ *
+ * Inject elasticsearch query to the preview area.
+ */
+function elasticsearch_helper_views_views_preview_info_alter(&$rows, $executable) {
+  if (is_a($executable->query,'Drupal\elasticsearch_helper_views\Plugin\views\query\Elasticsearch')
+    && \Drupal::config('views.settings')->get('ui.show.sql_query.enabled')) {
+    $query = $executable->query->query();
+    $rows['query'][0][1]['data']['#context']['query'] =  json_encode($query, JSON_PRETTY_PRINT);
+  }
+}


### PR DESCRIPTION
I really don't like $rows['query'][0][1]['data']['#context']['query'], but that has to be fixed in Views UI