### PR TITLE
Cache context support is added to Elasticsearch query plugins

### DIFF
--- a/src/ElasticsearchQueryBuilderInterface.php
+++ b/src/ElasticsearchQueryBuilderInterface.php
@@ -3,12 +3,13 @@
 namespace Drupal\elasticsearch_helper_views;
 
 use Drupal\Component\Plugin\PluginInspectionInterface;
+use Drupal\Core\Cache\CacheableDependencyInterface;
 use Drupal\views\ViewExecutable;
 
 /**
  * Defines an interface for Elasticsearch query builder plugins.
  */
-interface ElasticsearchQueryBuilderInterface extends PluginInspectionInterface {
+interface ElasticsearchQueryBuilderInterface extends PluginInspectionInterface, CacheableDependencyInterface {
 
   /**
    * Builds Elasticsearch query based on given query/filter values.

--- a/src/Plugin/ElasticsearchQueryBuilder/ElasticsearchQueryBuilderPluginBase.php
+++ b/src/Plugin/ElasticsearchQueryBuilder/ElasticsearchQueryBuilderPluginBase.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\elasticsearch_helper_views\Plugin\ElasticsearchQueryBuilder;
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\elasticsearch_helper_views\ElasticsearchQueryBuilderInterface;
 use Drupal\views\Plugin\views\display\DisplayPluginBase;
@@ -86,7 +87,17 @@ abstract class ElasticsearchQueryBuilderPluginBase extends PluginBase implements
    * {@inheritdoc}
    */
   public function getCacheContexts() {
-    return [];
+    $contexts = [];
+
+    // Merge in cache contexts for all exposed filters.
+    foreach ($this->displayHandler->getHandlers('filter') as $filter_handler) {
+      /** @var \Drupal\views\Plugin\views\Filter\FilterPluginBase $filter_handler */
+      if ($filter_handler->isExposed()) {
+        $contexts = Cache::mergeContexts($contexts, $filter_handler->getCacheContexts());
+      }
+    }
+
+    return $contexts;
   }
 
   /**

--- a/src/Plugin/ElasticsearchQueryBuilder/ElasticsearchQueryBuilderPluginBase.php
+++ b/src/Plugin/ElasticsearchQueryBuilder/ElasticsearchQueryBuilderPluginBase.php
@@ -2,9 +2,10 @@
 
 namespace Drupal\elasticsearch_helper_views\Plugin\ElasticsearchQueryBuilder;
 
-use Drupal\Component\Plugin\PluginBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\elasticsearch_helper_views\ElasticsearchQueryBuilderInterface;
+use Drupal\views\Plugin\views\display\DisplayPluginBase;
+use Drupal\views\Plugin\views\PluginBase;
 use Drupal\views\ViewExecutable;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -29,6 +30,13 @@ abstract class ElasticsearchQueryBuilderPluginBase extends PluginBase implements
       $plugin_id,
       $plugin_definition
     );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function init(ViewExecutable $view, DisplayPluginBase $display, array &$options = NULL) {
+    parent::init($view, $display, $options);
   }
 
   /**

--- a/src/Plugin/ElasticsearchQueryBuilder/ElasticsearchQueryBuilderPluginBase.php
+++ b/src/Plugin/ElasticsearchQueryBuilder/ElasticsearchQueryBuilderPluginBase.php
@@ -75,4 +75,25 @@ abstract class ElasticsearchQueryBuilderPluginBase extends PluginBase implements
     return $arguments;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheMaxAge() {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheTags() {
+    return [];
+  }
+
 }

--- a/src/Plugin/views/query/Elasticsearch.php
+++ b/src/Plugin/views/query/Elasticsearch.php
@@ -520,6 +520,27 @@ class Elasticsearch extends QueryPluginBase {
   /**
    * {@inheritdoc}
    */
+  public function getCacheContexts() {
+    $contexts = [];
+
+    // Get cache context from the query builder.
+    $contexts = Cache::mergeContexts($contexts, $this->getQueryBuilder()->getCacheContexts());
+
+    // Add base entity type cache context.
+    if (isset($this->options['entity_relationship']['entity_type_key'])) {
+      $entity_type_id = $this->getNestedValue($this->options['entity_relationship']['entity_type_key'], []);
+
+      if ($entity_type = \Drupal::entityManager()->getDefinition($entity_type_id, FALSE)) {
+        $contexts = Cache::mergeContexts($contexts, $entity_type->getListCacheContexts());
+      }
+    }
+
+    return $contexts;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getCacheMaxAge() {
     $max_age = parent::getCacheMaxAge();
     foreach ($this->getAllEntities() as $entity) {

--- a/src/Plugin/views/query/Elasticsearch.php
+++ b/src/Plugin/views/query/Elasticsearch.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\elasticsearch_helper_views\ElasticsearchQueryBuilderInterface;
 use Drupal\elasticsearch_helper_views\ElasticsearchQueryBuilderManager;
+use Drupal\views\Plugin\views\display\DisplayPluginBase;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\views\ResultRow;
 use Drupal\views\ViewExecutable;
@@ -68,6 +69,13 @@ class Elasticsearch extends QueryPluginBase {
       $container->get('entity_type.manager'),
       $container->get('elasticsearch_query_builder.manager')
     );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function init(ViewExecutable $view, DisplayPluginBase $display, array &$options = NULL) {
+    parent::init($view, $display, $options);
   }
 
   /**
@@ -226,6 +234,9 @@ class Elasticsearch extends QueryPluginBase {
     if ($this->options['query_builder'] && !isset($this->queryBuilder)) {
       try {
         $this->queryBuilder = $this->elasticsearchQueryBuilderManager->createInstance($this->options['query_builder']);
+        $options = [];
+        // Initialize the plugin.
+        $this->queryBuilder->init($this->view, $this->displayHandler, $options);
       } catch (\Exception $e) {
         watchdog_exception('elasticsearch_helper_views', $e);
       }


### PR DESCRIPTION
Also, the following changes are implemented:
- `init()` method added to `Elasticsearch` and `ElasticsearchQueryBuilderPluginBase` classes so that they have access to the view instance
- `ElasticsearchQueryBuilderPluginBase` implements `CacheableDependencyInterface` which means that Elasticsearch query builder plugins can define their own cache metadata
- Exposed filter plugin cache contexts are merged into `ElasticsearchQueryBuilderPluginBase` cache context metadata


