### PR TITLE
Existence of query builder plugin is determined before merging cache contexts from it

### DIFF
--- a/src/Plugin/views/query/Elasticsearch.php
+++ b/src/Plugin/views/query/Elasticsearch.php
@@ -535,7 +535,9 @@ class Elasticsearch extends QueryPluginBase {
     $contexts = [];
 
     // Get cache context from the query builder.
-    $contexts = Cache::mergeContexts($contexts, $this->getQueryBuilder()->getCacheContexts());
+    if ($query_builder = $this->getQueryBuilder()) {
+      $contexts = Cache::mergeContexts($contexts, $query_builder->getCacheContexts());
+    }
 
     // Add base entity type cache context.
     if (isset($this->options['entity_relationship']['entity_type_key'])) {


### PR DESCRIPTION
This fixes a bug where an error is thrown when a new view is created and query builder plugin is not yet defined.