### PR TITLE
Signature of query builder interface changed

### DIFF
--- a/src/ElasticsearchQueryBuilderInterface.php
+++ b/src/ElasticsearchQueryBuilderInterface.php
@@ -4,7 +4,6 @@ namespace Drupal\elasticsearch_helper_views;
 
 use Drupal\Component\Plugin\PluginInspectionInterface;
 use Drupal\Core\Cache\CacheableDependencyInterface;
-use Drupal\views\ViewExecutable;
 
 /**
  * Defines an interface for Elasticsearch query builder plugins.
@@ -17,39 +16,32 @@ interface ElasticsearchQueryBuilderInterface extends PluginInspectionInterface, 
    * The query array needs to be compatible with
    * \Elasticsearch\Client::search().
    *
-   * @param ViewExecutable $view
-   *
    * @return array
    *
    * @see \Elasticsearch\Client::search()
    */
-  public function buildQuery(ViewExecutable $view);
+  public function buildQuery();
 
   /**
    * Returns filter values from a view.
    *
-   * @param \Drupal\views\ViewExecutable $view
-   *
    * @return array
    */
-  public function getFilterValues(ViewExecutable $view);
+  public function getFilterValues();
 
   /**
    * Returns argument values from a view.
    *
-   * @param \Drupal\views\ViewExecutable $view
-   *
    * @return array
    */
-  public function getArgumentValues(ViewExecutable $view);
+  public function getArgumentValues();
 
   /**
    * Returns sort values from a view.
    *
-   * @param \Drupal\views\ViewExecutable $view
-   *
    * @return array
+   *
    */
-  public function getSortValues(ViewExecutable $view);
+  public function getSortValues();
 
 }

--- a/src/Plugin/ElasticsearchQueryBuilder/DefaultElasticsearchQueryBuilder.php
+++ b/src/Plugin/ElasticsearchQueryBuilder/DefaultElasticsearchQueryBuilder.php
@@ -3,7 +3,6 @@
 namespace Drupal\elasticsearch_helper_views\Plugin\ElasticsearchQueryBuilder;
 
 use Drupal\elasticsearch_helper_views\ElasticsearchQueryBuilderInterface;
-use Drupal\views\ViewExecutable;
 
 /**
  * @ElasticsearchQueryBuilder(
@@ -17,7 +16,7 @@ class DefaultElasticsearchQueryBuilder extends ElasticsearchQueryBuilderPluginBa
   /**
    * {@inheritdoc}
    */
-  public function buildQuery(ViewExecutable $view) {
+  public function buildQuery() {
     return [];
   }
 

--- a/src/Plugin/ElasticsearchQueryBuilder/ElasticsearchQueryBuilderPluginBase.php
+++ b/src/Plugin/ElasticsearchQueryBuilder/ElasticsearchQueryBuilderPluginBase.php
@@ -43,12 +43,12 @@ abstract class ElasticsearchQueryBuilderPluginBase extends PluginBase implements
   /**
    * {@inheritdoc}
    */
-  public function getFilterValues(ViewExecutable $view) {
+  public function getFilterValues() {
     $values = [];
 
-    if (!empty($view->filter)) {
+    if (!empty($this->view->filter)) {
       /** @var \Drupal\views\Plugin\views\filter\FilterPluginBase $filter */
-      foreach ($view->filter as $filter) {
+      foreach ($this->view->filter as $filter) {
         $values[$filter->realField] = $filter->value;
       }
     }
@@ -59,12 +59,12 @@ abstract class ElasticsearchQueryBuilderPluginBase extends PluginBase implements
   /**
    * {@inheritdoc}
    */
-  public function getArgumentValues(ViewExecutable $view) {
+  public function getArgumentValues() {
     $values = [];
 
-    if (!empty($view->argument)) {
+    if (!empty($this->view->argument)) {
       /** @var \Drupal\views\Plugin\views\argument\ArgumentPluginBase $argument */
-      foreach ($view->argument as $argument) {
+      foreach ($this->view->argument as $argument) {
         $values[$argument->realField] = $argument->getValue();
       }
     }
@@ -75,12 +75,12 @@ abstract class ElasticsearchQueryBuilderPluginBase extends PluginBase implements
   /**
    * {@inheritdoc}
    */
-  public function getSortValues(ViewExecutable $view) {
+  public function getSortValues() {
     $values = [];
 
-    if (!empty($view->sort)) {
+    if (!empty($this->view->sort)) {
       /** @var \Drupal\views\Plugin\views\sort\SortPluginBase $sort */
-      foreach ($view->sort as $sort) {
+      foreach ($this->view->sort as $sort) {
         $values[$sort->realField] = strtolower($sort->options['order']);
       }
     }

--- a/src/Plugin/views/query/Elasticsearch.php
+++ b/src/Plugin/views/query/Elasticsearch.php
@@ -251,7 +251,7 @@ class Elasticsearch extends QueryPluginBase {
   public function query($get_count = FALSE) {
     /** @var ElasticsearchQueryBuilderInterface $query_builder */
     $query_builder = $this->getQueryBuilder();
-    $query = $query_builder->buildQuery($this->view);
+    $query = $query_builder->buildQuery();
 
     // Apply limit and offset to the query.
     $limits = [


### PR DESCRIPTION
Query builder methods do not require explicit Views object anymore as it's already available via `$this->view`.

This change is not backwards compatible, which means that query builder plugins need to be updated to be compatible with the interface.